### PR TITLE
Added additional http request status 409 checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.0.3
+### Added
+- `resolveCorrelationId` additionally checks if http request status is 409
+
 ## 2.0.2
 ### Fixed
 - `resolveByResponseErrors` handled `{ errors: null }` case

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@paysera/error-message-resolver",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "Library that helps resolve error messages",
     "main": "dist/main.js",
     "module": "es/index.js",

--- a/src/additionalMessageResolver/__tests__/resolveCorrelationId.test.js
+++ b/src/additionalMessageResolver/__tests__/resolveCorrelationId.test.js
@@ -62,6 +62,21 @@ describe('resolveCorrelationId', () => {
             'Error code: abc',
         ],
         [
+            'For http errors with a status equal to 409 returns `paysera-correlation-id` from response headers',
+            {
+                config: {},
+                request: {},
+                response: {
+                    status: 409,
+                    data: {},
+                    headers: {
+                        'paysera-correlation-id': 'abc',
+                    },
+                },
+            },
+            'Error code: abc',
+        ],
+        [
             'For http errors with a status equal to 500 returns `paysera-correlation-id` from response headers',
             {
                 config: {},

--- a/src/additionalMessageResolver/resolveCorrelationId.js
+++ b/src/additionalMessageResolver/resolveCorrelationId.js
@@ -18,6 +18,7 @@ const resolveCorrelationId = async (error) => {
         errorResponse.getStatus() < 500
         && errorResponse.getStatus() !== 401
         && errorResponse.getStatus() !== 403
+        && errorResponse.getStatus() !== 409
     ) {
         return null;
     }


### PR DESCRIPTION
Right now, when request returns 409 no additional secondary message with error code is shown.

With these error code is shown for requests that return 409 too.